### PR TITLE
Added before_install travis hook to agree to android-28 sdk licenses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
   - android-28
 
 before_install:
-    - yes | sdkmanager "build-tools;platforms;android-27;android-28"
+    - yes | sdkmanager "build-tools;27.0.3" "build-tools;28.0.3" "platforms;android-27" "platforms;android-28"
 
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ android:
   - build-tools-28.0.3
   - android-28
 
+before_install:
+    - yes | sdkmanager "platforms;android-28"
+
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock
 - rm -fr ${HOME}/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ android:
   components:
   - tools
   - platform-tools
+  - build-tools-27.0.3
   - build-tools-28.0.3
+  - android-27
   - android-28
 
 before_install:
-    - yes | sdkmanager "build-tools;platforms;android-28"
+    - yes | sdkmanager "build-tools;platforms;android-27;android-28"
 
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
   - android-28
 
 before_install:
-    - yes | sdkmanager "platforms;android-28"
+    - yes | sdkmanager "build-tools;platforms;android-28"
 
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
It was the recommended fix for the error message: `Failed to install the following Android SDK packages as some licences have not been accepted.`: https://github.com/travis-ci/travis-ci/issues/8879