### PR TITLE
Make Bento Logo in Readme be fluid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./documentation/images/bento_logo.png" height="150"/>
+<img src="./documentation/images/bento_logo.png" width="80%"/>
 
 ## A delicious framework for building modularized Android user interfaces, by Yelp.
 


### PR DESCRIPTION
Looks like the Bento logo in the readme is not responsive and looks really bad on mobile.

| Before | After |
| --- | --- |
| ![Screenshot 2019-05-03 at 16 40 42](https://user-images.githubusercontent.com/3001957/57144955-82612b80-6dc2-11e9-8637-3243bcbf930f.png) | ![Screenshot 2019-05-03 at 16 40 33](https://user-images.githubusercontent.com/3001957/57144964-87be7600-6dc2-11e9-857f-5f023ea0a903.png) |

