### PR TITLE
Added check for gap in ComponentGroup

### DIFF
--- a/bento/src/main/java/com/yelp/android/bento/core/ComponentGroup.java
+++ b/bento/src/main/java/com/yelp/android/bento/core/ComponentGroup.java
@@ -40,6 +40,9 @@ public class ComponentGroup extends Component {
         mSpanSizeLookup = new SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {
+                if (hasGap(position)) {
+                    return getNumberLanes();
+                }
                 RangedValue<Component> rangedValue = mComponentAccordionList.rangedValueAt(position);
                 return rangedValue.mValue
                         .getSpanSizeLookup()

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import java.net.URI
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "15.0.0"
+    const val VERSION = "15.1.0"
 }
 
 object Versions {

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import java.net.URI
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "15.1.0"
+    const val VERSION = "15.1.1"
 }
 
 object Versions {


### PR DESCRIPTION
There is a bug where adding a gap to headers can cause an exception to be thrown when calculating a component span. This commit checks to see if the requested index is a gap, then sets the span to the component's number of columns.