### PR TITLE
Simplifies .travis.yml file to make it work.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 
-jdk: openjdk8
+jdk: openjdk11
 
 os:
 - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: android
-
-jdk: openjdk11
-
-os:
-- linux
+dist: bionic
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ android:
   - android-27
   - android-28
 
-before_install:
-    - yes | sdkmanager "build-tools;27.0.3" "build-tools;28.0.3" "platforms;android-27" "platforms;android-28"
-
 before_cache:
 - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock
 - rm -fr ${HOME}/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 
-jdk: oraclejdk8
+jdk: openjdk8
 
 os:
 - linux


### PR DESCRIPTION
(Travis seems to not like oracle jdk 8 anymore)