### PR TITLE
Specify the bento_ prefix in the gradle configuration

### DIFF
--- a/bento/build.gradle
+++ b/bento/build.gradle
@@ -29,6 +29,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    resourcePrefix 'bento_'
 }
 
 task androidSourcesJar(type: Jar) {


### PR DESCRIPTION
Future resources will have to begin with bento_ as well.