### PR TITLE
Save scroll position of the CarouselComponent when scrolled offscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bento Releases
 
+## Version 15.3.0
+_2018-08-13_
+* Behavior change: CarouselComponent now remembers its scroll position when it's scrolled offscreen.
+
 ## Version 15.2.0
 _2018-08-07_
 * New: Added TabViewPagerComponent to use both TabLayout and ViewPager in one view.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ You can also run `./gradlew publishToMavenLocal` to publish the package to your 
 
 We follow [semver](https://semver.org/) so the version number in `GlobalDependencies.kt` should be updated to reflect the changes.
 
+Add a summary of your change to the `CHANGELOG.md` file.
+
 #### 5. Push your changes and open a pull request
 
 Push your branch with the new commits to your cloned repo, then open a pull request through GitHub. Once Travis CI gives it a green light along with a member of our team, it will be merged and the new version will be deployed to Maven Central.

--- a/bento/src/androidTest/java/com/yelp/android/bento/test/CarouselComponentViewHolderTest.kt
+++ b/bento/src/androidTest/java/com/yelp/android/bento/test/CarouselComponentViewHolderTest.kt
@@ -117,6 +117,23 @@ class CarouselComponentViewHolderTest: ComponentViewHolderTestCase<Unit?, Carous
             assertEquals(0, holder.element.scrollPositionOffset)
         }
     }
+
+    @Test
+    fun scrollingEmptyCarousel_SavesScrollPosition() {
+        val pool = RecyclerView.RecycledViewPool()
+
+        bindViewHolder(CarouselComponentViewHolder::class.java, null, CarouselViewModel(ComponentGroup(), pool))
+        val holder = getHolder<CarouselComponentViewHolder>()
+
+        val scrollToPosition = 3
+        holder.recyclerView.layoutManager?.smoothScrollToPosition(
+                holder.recyclerView, null, scrollToPosition)
+
+        RecyclerViewScrollStateIdlingResource(holder.recyclerView).registerIdleTransitionCallback {
+            assertEquals(0, holder.element.scrollPosition)
+            assertEquals(0, holder.element.scrollPositionOffset)
+        }
+    }
 }
 
 private class RecyclerViewScrollStateIdlingResource(recyclerView: RecyclerView) : IdlingResource {

--- a/bento/src/androidTest/java/com/yelp/android/bento/test/CarouselComponentViewHolderTest.kt
+++ b/bento/src/androidTest/java/com/yelp/android/bento/test/CarouselComponentViewHolderTest.kt
@@ -1,6 +1,11 @@
 package com.yelp.android.bento.test
 
+import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.SCROLL_STATE_IDLE
+import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.IdlingResource.ResourceCallback
 import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController
 import com.yelp.android.bento.components.CarouselComponent
 import com.yelp.android.bento.components.CarouselComponentViewHolder
@@ -64,6 +69,115 @@ class CarouselComponentViewHolderTest: ComponentViewHolderTestCase<Unit?, Carous
         controller.addComponent(group)
         carousels.forEachIndexed { index, carousel ->
             assertEquals("At carousel: $index", pool, carousel.getItem(0).sharedPool)
+        }
+    }
+
+    @Test
+    fun savedScrollPositionWithOffset_IsRestoredOnBind() {
+        val group = ComponentGroup()
+        group.addAll((1..20).map { SimpleComponent<Unit>(TestComponentViewHolder::class.java) })
+        val pool = RecyclerView.RecycledViewPool()
+
+        bindViewHolder(
+                CarouselComponentViewHolder::class.java,
+                null,
+                CarouselViewModel(group, pool, scrollPosition = 3, scrollPositionOffset = -200)
+        )
+        val (recyclerView, element) = getHolder<CarouselComponentViewHolder>().let {
+            Pair(it.recyclerView, it.element)
+        }
+
+        ViewAttachedToWindowIdlingResource(recyclerView).registerIdleTransitionCallback {
+            val firstVisibleItemPosition =
+                    (recyclerView.layoutManager as? LinearLayoutManager)
+                            ?.findFirstVisibleItemPosition()
+
+            val firstVisibleItemOffset = recyclerView.getChildAt(0).left - recyclerView.paddingLeft
+
+            assertEquals(element.scrollPosition, firstVisibleItemPosition)
+            assertEquals(element.scrollPositionOffset, firstVisibleItemOffset)
+        }
+    }
+
+    @Test
+    fun scrollingCarousel_SavesScrollPosition() {
+        val group = ComponentGroup()
+        group.addAll((1..20).map { SimpleComponent<Unit>(TestComponentViewHolder::class.java) })
+        val pool = RecyclerView.RecycledViewPool()
+
+        bindViewHolder(CarouselComponentViewHolder::class.java, null, CarouselViewModel(group, pool))
+        val holder = getHolder<CarouselComponentViewHolder>()
+
+        val scrollToPosition = 3
+        holder.recyclerView.layoutManager?.smoothScrollToPosition(
+                holder.recyclerView, null, scrollToPosition)
+
+        RecyclerViewScrollStateIdlingResource(holder.recyclerView).registerIdleTransitionCallback {
+            assertEquals(scrollToPosition, holder.element.scrollPosition)
+            assertEquals(0, holder.element.scrollPositionOffset)
+        }
+    }
+}
+
+private class RecyclerViewScrollStateIdlingResource(recyclerView: RecyclerView) : IdlingResource {
+
+    private var mIdle = false
+
+    private lateinit var mResourceCallback: ResourceCallback
+
+    init {
+        recyclerView.addOnScrollListener(IdleScrollListener())
+    }
+
+    override fun getName() = "RecyclerViewScrollStateIdlingResource"
+
+    override fun isIdleNow(): Boolean {
+        return mIdle
+    }
+
+    override fun registerIdleTransitionCallback(resourceCallback: ResourceCallback) {
+        mResourceCallback = resourceCallback
+    }
+
+    private inner class IdleScrollListener: RecyclerView.OnScrollListener() {
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            super.onScrollStateChanged(recyclerView, newState)
+            if (newState == SCROLL_STATE_IDLE) {
+                mIdle = true
+                mResourceCallback.onTransitionToIdle()
+            }
+        }
+    }
+}
+
+private class ViewAttachedToWindowIdlingResource(view: View) : IdlingResource {
+
+    private var mIdle = false
+
+    private lateinit var mResourceCallback: ResourceCallback
+
+    init {
+        view.addOnAttachStateChangeListener(OnAttachListener())
+    }
+
+    override fun getName() = "ViewAttachedToWindowIdlingResource"
+
+    override fun isIdleNow(): Boolean {
+        return mIdle
+    }
+
+    override fun registerIdleTransitionCallback(resourceCallback: ResourceCallback) {
+        mResourceCallback = resourceCallback
+    }
+
+    private inner class OnAttachListener: View.OnAttachStateChangeListener {
+        override fun onViewDetachedFromWindow(v: View?) {
+            // Do nothing.
+        }
+
+        override fun onViewAttachedToWindow(v: View?) {
+            mIdle = true
+            mResourceCallback.onTransitionToIdle()
         }
     }
 }

--- a/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
+++ b/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
@@ -75,20 +75,6 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
     lateinit var element: CarouselViewModel
     private var attachedPool = false
 
-    /**
-     * Saves the scroll position of the carousel to the view model so that it can be restored when
-     * the carousel recyclerView itself is recycled in the larger component list. Scroll position
-     * is saved when the scroll state of the carousel transitions to
-     * [RecyclerView.SCROLL_STATE_IDLE].
-     */
-    private fun saveScrollPosition() {
-        (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
-            element.scrollPosition = findFirstVisibleItemPosition()
-            element.scrollPositionOffset =
-                    recyclerView.getChildAt(0).left - recyclerView.paddingLeft
-        }
-    }
-
     final override fun inflate(parent: ViewGroup): View {
         return createRecyclerView(parent).apply {
             recyclerView = this
@@ -120,6 +106,8 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
             controller.addComponent(group)
         }
 
+        // The post is required because it's possible that the scroll will fail if the items in the
+        // carousel have not already been measured and laid out.
         recyclerView.post {
             (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
                 scrollToPositionWithOffset(element.scrollPosition, element.scrollPositionOffset)
@@ -135,6 +123,25 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
      */
     open fun createRecyclerView(parent: ViewGroup): RecyclerView {
         return parent.inflate(R.layout.bento_recycler_view)
+    }
+
+    /**
+     * Saves the scroll position of the carousel to the view model so that it can be restored when
+     * the carousel recyclerView itself is recycled in the larger component list. Scroll position
+     * is saved when the scroll state of the carousel transitions to
+     * [RecyclerView.SCROLL_STATE_IDLE].
+     */
+    private fun saveScrollPosition() {
+        if (recyclerView.childCount < 1) {
+            element.scrollPosition = 0
+            element.scrollPositionOffset = 0
+            return
+        }
+        (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
+            element.scrollPosition = findFirstVisibleItemPosition()
+            element.scrollPositionOffset =
+                    recyclerView.getChildAt(0).left - recyclerView.paddingLeft
+        }
     }
 }
 

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import java.net.URI
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "15.2.0"
+    const val VERSION = "15.3.0"
 }
 
 object Versions {


### PR DESCRIPTION
- Added two new fields to the `CarouselViewModel` to save scroll position
- Made the viewModel a member of the CarouselComponent so it can remember where it was
- Updated the contributing steps to include updating the CHANGELOG.md file because I saw it was a missing step
- Added tests for saving and restoring scroll position to the carousel