### PR TITLE
Updated Travis dist to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: android
-dist: bionic
+dist: trusty
 
 android:
   components:


### PR DESCRIPTION
Looks like Travis is currently broken on master.
The reason is that we're currently using `dist: bionic` while Android is supported only on `trusty`: https://docs.travis-ci.com/user/languages/android/#overview