### PR TITLE
Add check for -1 when reordering items and explicitly throwing detailed exception when rangedValueAt has an error.

### DIFF
--- a/bento/src/main/java/com/yelp/android/bento/core/ListItemTouchCallback.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/ListItemTouchCallback.kt
@@ -39,11 +39,11 @@ class ListItemTouchCallback(
             viewHolder: RecyclerView.ViewHolder
     ): Int {
         val currentIndex = viewHolder.adapterPosition
-        return if (currentIndex == RecyclerView.NO_POSITION ||
-                !canReorderItemAtIndex(currentIndex)) {
-            makeMovementFlags(0, 0)
-        } else {
+        return if (currentIndex != RecyclerView.NO_POSITION &&
+                canReorderItemAtIndex(currentIndex)) {
             makeMovementFlags(DRAG_FLAGS, 0)
+        } else {
+            makeMovementFlags(0, 0)
         }
     }
 

--- a/bento/src/main/java/com/yelp/android/bento/core/ListItemTouchCallback.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/ListItemTouchCallback.kt
@@ -38,10 +38,12 @@ class ListItemTouchCallback(
             recyclerView: RecyclerView,
             viewHolder: RecyclerView.ViewHolder
     ): Int {
-        return if (canReorderItemAtIndex(viewHolder.adapterPosition)) {
-            makeMovementFlags(DRAG_FLAGS, 0)
-        } else {
+        val currentIndex = viewHolder.adapterPosition
+        return if (currentIndex == RecyclerView.NO_POSITION ||
+                !canReorderItemAtIndex(currentIndex)) {
             makeMovementFlags(0, 0)
+        } else {
+            makeMovementFlags(DRAG_FLAGS, 0)
         }
     }
 
@@ -81,7 +83,7 @@ class ListItemTouchCallback(
         dragFrom = dragTo
     }
 
-    private fun canReorderItemAtIndex(index: Int) : Boolean {
+    private fun canReorderItemAtIndex(index: Int): Boolean {
         val targetRangeValue = component.findRangedComponentWithIndex(index)
         val targetComponent = targetRangeValue.mValue
         return targetComponent.canPickUpItem(index - targetRangeValue.mRange.mLower)

--- a/bento/src/main/java/com/yelp/android/bento/utils/AccordionList.java
+++ b/bento/src/main/java/com/yelp/android/bento/utils/AccordionList.java
@@ -66,7 +66,13 @@ public class AccordionList<T> implements Iterable<RangedValue<T>> {
      */
     @NonNull
     public RangedValue<T> rangedValueAt(int location) {
-        return mRangeList.get(Collections.binarySearch(mRangeList, location));
+        int foundLocation = Collections.binarySearch(mRangeList, location);
+
+        if (foundLocation < 0) {
+            throw new ArrayIndexOutOfBoundsException("Could not find value at index: " + location +
+                    ". BinarySearch returned: " + foundLocation);
+        }
+        return mRangeList.get(foundLocation);
     }
 
     /**

--- a/bento/src/main/java/com/yelp/android/bento/utils/AccordionList.java
+++ b/bento/src/main/java/com/yelp/android/bento/utils/AccordionList.java
@@ -69,8 +69,11 @@ public class AccordionList<T> implements Iterable<RangedValue<T>> {
         int foundLocation = Collections.binarySearch(mRangeList, location);
 
         if (foundLocation < 0) {
-            throw new ArrayIndexOutOfBoundsException("Could not find value at index: " + location +
-                    ". BinarySearch returned: " + foundLocation);
+            throw new ArrayIndexOutOfBoundsException(
+                    "Could not find value at index: " + location + ".\n" +
+                            "BinarySearch returned: " + foundLocation + ".\n" +
+                            describeAccordionList()
+            );
         }
         return mRangeList.get(foundLocation);
     }
@@ -176,6 +179,20 @@ public class AccordionList<T> implements Iterable<RangedValue<T>> {
         for (int i = entryIndex; i < mRangeList.size(); i++) {
             mRangeList.set(i, mRangeList.get(i).offset(offset));
         }
+    }
+
+    private String describeAccordionList() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("AccordionList has size: ")
+                .append(mRangeList.size())
+                .append(". /n")
+                .append("Items in AccordionList:\n");
+
+        for (RangedValue<T> range : mRangeList) {
+            builder.append(range.toString());
+        }
+
+        return builder.toString();
     }
 
     private class AccordionListIterator implements Iterator<RangedValue<T>> {

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import java.net.URI
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "15.3.1"
+    const val VERSION = "15.3.2"
 }
 
 object Versions {


### PR DESCRIPTION
We have a rare crash we can not repro in `getMovementFlags`. The leading theory is that `viewHolder.adapterPosition` is returning  `RecyclerView.NO_POSITION`, which it explicitly can. This is then being passed to `rangedValueAt`, where it is crashing.

Our solution is twofold:
1. Check if `viewHolder.adapterPosition == RecyclerView.NO_POSITION` and return if it does.
2. Add an explicit and detailed exception when `rangedValueAt` can't find an item to make debugging easier in the future.

Note: Because we can not repro this, we can not test the solution to ensure it fixes the problem. I have tested all of the screens in the Bento sample app, so I am confident that, though this may not fix the problem, it will not cause any harm.