### PR TITLE
Updated changelog for previous commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Bento Releases
 
-## Version 15.3.1
+## Version 15.3.2
 _2019-10-08_
 * Fix: Fixed bug in ListItemTouchCallback causing crash when viewHolder.adapterPosition is -1
 * Fix: Add detailed exception thrown when AccordionList.rangedValueAt is called with an incorrect value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Bento Releases
 
 ## Version 15.3.1
+_2019-10-08_
+* Fix: Fixed bug in ListItemTouchCallback causing crash when viewHolder.adapterPosition is -1
+* Fix: Add detailed exception thrown when AccordionList.rangedValueAt is called with an incorrect value.
+
+## Version 15.3.1
 _2019-08-29_
 * Fix: Fixed appending data to ListComponent.
 * Fix: Fixed issue where we were no longer sharing the RecyclePool in CarouselComponent.


### PR DESCRIPTION
Forgot to update the changelog with https://github.com/Yelp/bento/pull/38.