### PR TITLE
Change NestedComponent to have separate presenter from its inner Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bento Releases
 
+## Version 15.6.0
+_2020-01-27_
+* Fix: Change NestedComponent to have separate presenter from its inner Component.
+
 ## Version 15.5.0
 _2020-01-16_
 * New: Add remove() and clear() functions to CarouselComponent.

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/ListViewActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/ListViewActivity.kt
@@ -131,7 +131,7 @@ class ListViewActivity : AppCompatActivity() {
                 NestedOuterComponentExampleViewHolder::class.java,
                 NestedOuterExampleViewModel("Nested component in ListView")
         )
-        val nestedComponent = NestedComponent(nestedViewModel)
+        val nestedComponent = NestedComponent(null, nestedViewModel)
         controller.addComponent(nestedComponent)
     }
 }

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
@@ -132,7 +132,7 @@ class RecyclerViewActivity : AppCompatActivity() {
                 NestedOuterComponentExampleViewHolder::class.java,
                 NestedOuterExampleViewModel("Nested component in RecyclerView")
         )
-        val nestedComponent = NestedComponent(nestedViewModel)
+        val nestedComponent = NestedComponent(null, nestedViewModel)
         controller.addComponent(nestedComponent)
     }
 }

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/ViewPagerActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/ViewPagerActivity.kt
@@ -134,7 +134,7 @@ class ViewPagerActivity : AppCompatActivity() {
                 NestedOuterComponentExampleViewHolder::class.java,
                 NestedOuterExampleViewModel("Nested component in ListView")
         )
-        val nestedComponent = NestedComponent(nestedViewModel)
+        val nestedComponent = NestedComponent(null, nestedViewModel)
         controller.addComponent(nestedComponent)
     }
 }

--- a/bento/src/main/java/com/yelp/android/bento/components/NestedComponent.kt
+++ b/bento/src/main/java/com/yelp/android/bento/components/NestedComponent.kt
@@ -19,9 +19,12 @@ import com.yelp.android.bento.utils.inflate
  * implement outerLayout and recyclerViewId to have it inflate the desired outer layout. Use
  * this new ViewHolder class to create the viewModel.
  */
-open class NestedComponent(private val viewModel: NestedViewModel<*, *>) : Component() {
+open class NestedComponent<P>(
+        private val presenter: P,
+        private val viewModel: NestedViewModel<*, *>
+) : Component() {
 
-    override fun getPresenter(position: Int) = viewModel.innerComponent.getPresenter(position)
+    override fun getPresenter(position: Int) = presenter
 
     override fun getItem(position: Int) = viewModel
 

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import java.net.URI
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "15.5.0"
+    const val VERSION = "15.6.0"
 }
 
 object Versions {


### PR DESCRIPTION
Currently, `NestedComponent`'s presenter is set to be inner `Component`'s presenter 

https://github.com/Yelp/bento/blob/48002fc6e1e920464364858e729d489a6b77a16c/bento/src/main/java/com/yelp/android/bento/components/NestedComponent.kt#L24

This makes it harder to re-use `NestedOuterComponentViewHolder`, which is `NestedComponent`'s `ComponentViewHolder`, since its presenter type must match with inner `Component`'s presenter type.

If we want to add multiple `NestedComponent` and the inner `Component`s have different presenter types, then we have to create multiple subclasses of `NestedOuterComponentViewHolder` and use different `NestedOuterComponentViewHolder`s for each `NestedComponent`. 

For example, if inner `Component`s have presenter type A, B, C, then we also have to create subclasses of `NestedOuterComponentViewHolder` with presenter type A, B, C.

By changing `NestedComponent` to have separate presenter from its inner `Component`, we can avoid creating multiple subclasses of `NestedOuterComponentViewHolder`, and make it easier to use `NestedComponent`.