### PR TITLE
fix(carousel): Fix CarouselComponent recycling behavior

### DIFF
--- a/bento-sample-app/src/main/AndroidManifest.xml
+++ b/bento-sample-app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         <activity android:name=".ReorderListActivity" />
         <activity android:name=".TabViewPagerActivity" />
         <activity android:name=".ToggleScrollInRecyclerViewActivity" />
+        <activity android:name=".RecyclingActivity" />
     </application>
 
 </manifest>

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/MainActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/MainActivity.kt
@@ -33,7 +33,8 @@ class MainActivity : AppCompatActivity() {
                 "Component Replacement" to ComponentReplacementActivity::class.java,
                 "Reorder Items" to ReorderListActivity::class.java,
                 "Tab View Pager" to TabViewPagerActivity::class.java,
-                "Toggle Scroll in RecyclerView" to ToggleScrollInRecyclerViewActivity::class.java
+                "Toggle Scroll in RecyclerView" to ToggleScrollInRecyclerViewActivity::class.java,
+                "Checking re-use of items" to RecyclingActivity::class.java
         ))
         componentController.addComponent(listComponent)
     }

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclingActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclingActivity.kt
@@ -1,0 +1,71 @@
+package com.yelp.android.bentosampleapp
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController
+import com.yelp.android.bento.components.CarouselComponent
+import com.yelp.android.bento.components.ListComponent
+import com.yelp.android.bento.core.ComponentController
+import com.yelp.android.bento.core.ComponentViewHolder
+import kotlinx.android.synthetic.main.activity_main.*
+
+class RecyclingActivity : AppCompatActivity() {
+    lateinit var componentController: ComponentController
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        componentController = RecyclerViewComponentController(recyclerView)
+
+        componentController.addComponent(CarouselComponent().apply {
+            addComponent(createListComponent(0..19))
+        })
+        componentController.addComponent(createListComponent(20..39))
+        componentController.addComponent(CarouselComponent().apply {
+            addComponent(createListComponent(40..59))
+        })
+        componentController.addComponent(createListComponent(60..79))
+    }
+
+    private fun createListComponent(range: IntRange): ListComponent<Any?, Int> {
+        return range.toList().let { cards ->
+            ListComponent(null, RecycledComponentViewHolder::class.java).apply {
+                setData(cards)
+                toggleDivider(false)
+            }
+        }
+    }
+
+    class RecycledComponentViewHolder : ComponentViewHolder<Any?, Int>() {
+        private lateinit var textView: TextView
+        private var isRecycled = false
+
+        override fun inflate(parent: ViewGroup): View {
+            return LayoutInflater.from(parent.context)
+                    .inflate(R.layout.simple_component_example, parent, false).also {
+                        textView = it.findViewById(R.id.text)
+                    }
+        }
+
+        override fun bind(presenter: Any?, element: Int) {
+            textView.text = getText(element)
+        }
+
+        override fun onViewRecycled() {
+            super.onViewRecycled()
+            isRecycled = true
+        }
+
+        private fun getText(element: Int): String {
+            return if (isRecycled) {
+                "Recycled $element"
+            } else {
+                "Non recycled $element"
+            }
+        }
+    }
+}

--- a/bento-sample-app/src/main/res/layout/simple_component_example.xml
+++ b/bento-sample-app/src/main/res/layout/simple_component_example.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="@drawable/black_border"
     android:layout_marginStart="8dp"
-    android:padding="10dp">
+    android:background="@drawable/black_border"
+    android:minWidth="150dp"
+    android:padding="10dp"
+    tools:text="Some text">
 
 </TextView>

--- a/bento/src/main/java/com/yelp/android/bento/componentcontrollers/ViewPagerComponentController.java
+++ b/bento/src/main/java/com/yelp/android/bento/componentcontrollers/ViewPagerComponentController.java
@@ -14,12 +14,10 @@ import com.yelp.android.bento.core.ComponentController;
 import com.yelp.android.bento.core.ComponentGroup;
 import com.yelp.android.bento.core.ComponentGroup.ComponentGroupDataObserver;
 import com.yelp.android.bento.utils.AccordionList.Range;
-
-import org.jetbrains.annotations.NotNull;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 /** Component controller that can be used at the top-level for adding components to a view pager. */
 public class ViewPagerComponentController extends PagerAdapter implements ComponentController {


### PR DESCRIPTION
- CarouselComponent will now recycle its children as soon as it leaves the screen
- Remove the ScrollListener logic to scroll back to position and replace it with storing and restoring the LinearLayoutManager's state.
- Added a RecyclingActivity to the bento sample app to play with recycling views.

Refs #62