### PR TITLE
Migrated to RxJava3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+## [18.0.0](https://github.com/Yelp/bento/compare/v17.0.0...v18.0.0) (2020-10-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* **deps:** Bump RxJava2 to RxJava3.
+
 
 ## [17.0.0](https://github.com/Yelp/bento/compare/v16.0.0...v17.0.0) (2020-12-14)
 

--- a/bento/src/main/java/com/yelp/android/bento/components/PaginatingListComponent.java
+++ b/bento/src/main/java/com/yelp/android/bento/components/PaginatingListComponent.java
@@ -8,8 +8,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.yelp.android.bento.R;
 import com.yelp.android.bento.core.ComponentViewHolder;
-import io.reactivex.Observable;
-import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
 
 /**
  * A {@link ListComponent} that supports pagination by exposing an {@link Observable} reporting the

--- a/bento/src/test/java/com/yelp/android/bento/components/PaginatingListComponentTest.java
+++ b/bento/src/test/java/com/yelp/android/bento/components/PaginatingListComponentTest.java
@@ -2,7 +2,7 @@ package com.yelp.android.bento.components;
 
 import static junit.framework.Assert.assertEquals;
 
-import io.reactivex.Observable;
+import io.reactivex.rxjava3.core.Observable;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -5,7 +5,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
 object Publishing {
     const val GROUP = "com.yelp.android"
-    const val VERSION = "17.0.0"
+    const val VERSION = "18.0.0"
 }
 
 object Versions {
@@ -30,7 +30,7 @@ object Versions {
     const val MAVEN_SETTINGS = "0.5"
     const val MOCKITO = "2.7.19"
     const val MOCKITO_KOTLIN = "2.1.0"
-    const val RX_JAVA_2 = "2.1.13"
+    const val RX_JAVA_3 = "3.0.7"
     const val SUPPORT_TEST = "1.0.2"
 }
 
@@ -44,7 +44,7 @@ object Libs {
     const val GUAVA = "com.google.guava:guava:${Versions.GUAVA}"
     const val KOTLIN = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.KOTLIN}"
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN}"
-    const val RX_JAVA_2 = "io.reactivex.rxjava2:rxjava:${Versions.RX_JAVA_2}"
+    const val RX_JAVA_2 = "io.reactivex.rxjava3:rxjava:${Versions.RX_JAVA_3}"
 }
 
 object PublishLibs {


### PR DESCRIPTION
- Migrated RxJava to v `3.0.7`
- Bumped lib version to `17.0.0` as this is a breaking change.