### PR TITLE
fix: Fix crash in ComponentVisibilityListener

### DIFF
--- a/bento/src/main/java/com/yelp/android/bento/core/ComponentVisibilityListener.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/ComponentVisibilityListener.kt
@@ -152,8 +152,10 @@ class ComponentVisibilityListener(
                     val firstVisible = layoutManagerHelper.findFirstVisibleItemPosition()
                     val lastVisible = layoutManagerHelper.findLastVisibleItemPosition()
 
-                    for (i in firstVisible..lastVisible) {
-                        componentGroup.notifyVisibilityChange(i, false)
+                    if (firstVisible != NO_POSITION || lastVisible != NO_POSITION) {
+                        for (i in firstVisible..lastVisible) {
+                            componentGroup.notifyVisibilityChange(i, false)
+                        }
                     }
                 }
 


### PR DESCRIPTION
Actually verifies that the item positions are different to NO_POSITION, which will prevent the index out of bounds exception.

Fixes #71 