### PR TITLE
chore: Setup workflow to replace travis ci

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -3,9 +3,60 @@ on: pull_request
 
 jobs:
   commitsar:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest]
     name: Verify commit messages
     steps:
       - uses: actions/checkout@v1
       - name: Run commitsar
         uses: docker://commitsar/commitsar
+  checks:
+    runs-on: [ubuntu-latest]
+    name: Run checks
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            cache-gradle-
+      - name: Run check
+        run: ./gradlew check
+  assemble:
+    runs-on: [ubuntu-latest]
+    name: Assemble the project
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            cache-gradle-
+      - name: Run assembleDebug
+        run: ./gradlew assembleDebug
+  publishToMavenLocal:
+    runs-on: [ubuntu-latest]
+    name: Publish to Maven local
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            cache-gradle-
+      - name: Run publishToMavenLocal
+        run: ./gradlew publishToMavenLocal


### PR DESCRIPTION
Maintaining travis seems a bit annoying, as we need to specify build version, accept license, etc... All of that that seem to work automatically with the github actions.
The idea would be to remove the travis run if this gets merged.