### PR TITLE
Added option to inflate views on a background thread.

### DIFF
--- a/bento-sample-app/build.gradle
+++ b/bento-sample-app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     // Support library dependencies.
     implementation SupportLibs.APP_COMPAT
     implementation SupportLibs.CONSTRAINT_LAYOUT
+    implementation Libs.COROUTINES
     implementation SupportLibs.DESIGN
     implementation SupportLibs.RECYCLERVIEW
 

--- a/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/MainActivityTest.kt
+++ b/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/MainActivityTest.kt
@@ -8,15 +8,23 @@ import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.filters.LargeTest
 import com.yelp.android.bento.testing.BentoInteraction
+import com.yelp.android.bento.utils.BentoSettings
+import com.yelp.android.bentosampleapp.rules.BeforeRule
 import org.hamcrest.Matchers.anything
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 @LargeTest
 class MainActivityTest {
 
+    private val beforeRule = BeforeRule {
+        BentoSettings.asyncInflationEnabled = false
+    }
+    private val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+
     @get:Rule
-    val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+    val rule: RuleChain = RuleChain.outerRule(beforeRule).around(intentsTestRule)
 
     @Test
     fun onData_atPosition2_clickOpensListViewActivity() {

--- a/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/RecyclerViewActivityTest.kt
+++ b/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/RecyclerViewActivityTest.kt
@@ -1,0 +1,31 @@
+package com.yelp.android.bentosampleapp
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.yelp.android.bento.utils.BentoSettings
+import com.yelp.android.bentosampleapp.rules.BeforeRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+
+class RecyclerViewActivityTest {
+
+    private val beforeRule = BeforeRule {
+        BentoSettings.asyncInflationEnabled = true
+    }
+    private val intentsTestRule = IntentsTestRule(RecyclerViewActivity::class.java)
+
+    @get:Rule
+    val rule: RuleChain = RuleChain.outerRule(beforeRule).around(intentsTestRule)
+
+    @Test
+    fun withAsyncInflationEnabled_scrollingDownDoesntCrash_andDisplaysItems() {
+        onView(withId(R.id.recyclerView)).perform(ViewActions.swipeUp())
+        onView(ViewMatchers.withText("List element 20"))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }
+}

--- a/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/rules/BeforeRule.kt
+++ b/bento-sample-app/src/androidTest/java/com/yelp/android/bentosampleapp/rules/BeforeRule.kt
@@ -1,0 +1,10 @@
+package com.yelp.android.bentosampleapp.rules
+
+import org.junit.rules.ExternalResource
+
+class BeforeRule(val beforeCallback: () -> Unit) : ExternalResource() {
+
+    override fun before() {
+        beforeCallback()
+    }
+}

--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/MainActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController
 import com.yelp.android.bento.components.ListComponent
+import com.yelp.android.bento.utils.BentoSettings
 import com.yelp.android.bentosampleapp.components.ActivityStarterViewHolder
 import kotlinx.android.synthetic.main.activity_main.*
 
@@ -14,6 +15,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        BentoSettings.asyncInflationEnabled = true
         componentController = RecyclerViewComponentController(recyclerView)
 
         val listComponent =

--- a/bento/build.gradle
+++ b/bento/build.gradle
@@ -30,6 +30,12 @@ android {
     }
 
     resourcePrefix 'bento_'
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 task androidSourcesJar(type: Jar) {
@@ -40,10 +46,9 @@ task androidSourcesJar(type: Jar) {
 dependencies {
     // Kotlin
     implementation Libs.KOTLIN
-
+    implementation Libs.COROUTINES
     // Apache Commons
     implementation Libs.APACHE_COMMONS
-
 
     // Guava
     implementation(Libs.GUAVA) {
@@ -56,8 +61,13 @@ dependencies {
     // Support library dependencies.
     implementation SupportLibs.APP_COMPAT
     implementation SupportLibs.DESIGN
+    implementation SupportLibs.LIFECYCLE
     implementation SupportLibs.RECYCLERVIEW
     androidTestImplementation TestLibs.SUPPORT_TEST_RULES
+
+    testImplementation TestLibs.CORE_KTX
+    testImplementation TestLibs.COROUTINES_TEST
+    testImplementation TestLibs.ROBOLECTRIC
 
     // JUnit
     testImplementation TestLibs.JUNIT

--- a/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationBridge.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationBridge.kt
@@ -1,0 +1,149 @@
+package com.yelp.android.bento.core
+
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
+import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController.constructViewHolder
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * This acts as a bridge between RecyclerViewComponentController and the underlying
+ * RecyclerView.Adapter. It intercepts the addComponent() calls and inflates views with
+ * [BentoAsyncLayoutInflater]. Components are added to the RecyclerView when the inflation
+ * is finished.
+ */
+internal class AsyncInflationBridge @JvmOverloads constructor(
+    val recyclerView: RecyclerView,
+    private val asyncInflaterDispatcher: CoroutineDispatcher = BentoAsyncLayoutInflater.dispatcher,
+    private val defaultBridgeDispatcher: CoroutineDispatcher = dispatcher
+) {
+
+    internal companion object {
+        private val lock = Mutex()
+
+        private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    }
+
+    private val viewHolderMap = ConcurrentHashMap<Class<out ComponentViewHolder<*, *>>,
+            ConcurrentLinkedDeque<ComponentViewHolder<*, *>>>()
+    private val viewMap = ConcurrentHashMap<ComponentViewHolder<*, *>, View?>()
+    private val inflationJobs = ConcurrentHashMap<Component, Job>()
+
+    private val context = recyclerView.context
+
+    @VisibleForTesting
+    val coroutineScope: CoroutineScope = if (context is LifecycleOwner) {
+        context.lifecycleScope.launch(Dispatchers.Main) {
+            context.lifecycle.addObserver(object : LifecycleObserver {
+                @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+                fun cleanUp() {
+                    viewHolderMap.clear()
+                    viewMap.clear()
+                    context.lifecycle.removeObserver(this)
+                }
+            })
+        }
+        context.lifecycleScope
+    } else {
+        GlobalScope
+    }
+
+    /**
+     * Inflates the views and creates the view holder for [component] on a background thread,
+     * getting them nice and ready for RecyclerViewComponentController to use them.
+     */
+    fun asyncInflateViewsForComponent(component: Component, addComponentCallback: () -> Unit) {
+        inflationJobs[component] = coroutineScope.launch(defaultBridgeDispatcher) {
+            val inflations = (0 until component.count).map { i ->
+                async {
+                    val viewHolderType = component.getHolderType(i)
+                    val viewHolder: ComponentViewHolder<*, *> = constructViewHolder(viewHolderType)
+                    addViewHolder(viewHolder, viewHolderType)
+                    val (_, view) = BentoAsyncLayoutInflater.inflate(viewHolder, recyclerView, asyncInflaterDispatcher)
+                    viewMap[viewHolder] = view
+                }
+            }
+            lock.withLock {
+                inflations.awaitAll()
+            }
+            withContext(Dispatchers.Main) {
+                executeAddComponentCallback(addComponentCallback)
+            }
+        }
+    }
+
+    /**
+     * Retrieves a previously async inflated view if there is one.
+     */
+    fun getView(viewHolder: ComponentViewHolder<*, *>) = viewMap.remove(viewHolder)
+
+    /**
+     * Retrieves a previously created view holder of the passed in [viewHolderType].
+     */
+    fun getViewHolder(
+        viewHolderType: Any? // Class<out ComponentViewHolder<*, *>> doesn't work with Java.
+    ): ComponentViewHolder<*, *>? {
+        if (viewHolderMap.containsKey(viewHolderType)) {
+            viewHolderMap[viewHolderType]?.let { list ->
+                if (list.isNotEmpty()) {
+                    return list.poll()
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Cancels [component]'s inflation job if the component was removed.
+     */
+    fun trackComponentRemoval(component: Component) {
+        inflationJobs[component]?.cancel()
+    }
+
+    private fun addViewHolder(
+        viewHolder: ComponentViewHolder<*, *>,
+        viewHolderType: Class<out ComponentViewHolder<*, *>>
+    ) {
+        val viewHolders = viewHolderMap.getOrPut(viewHolderType) {
+            ConcurrentLinkedDeque()
+        }
+        viewHolders.add(viewHolder)
+        viewHolderMap[viewHolderType] = viewHolders
+    }
+
+    /**
+     * Executes RecyclerViewComponentController's addComponent() callback on the main thread.
+     */
+    private fun executeAddComponentCallback(
+        addComponentCallback: () -> Unit
+    ) {
+        try {
+            addComponentCallback()
+        } catch (exception: IllegalArgumentException) {
+            exception.message?.let { message ->
+                if (!message.contains("already added")) {
+                    throw exception
+                }
+            }
+        }
+    }
+}

--- a/bento/src/main/java/com/yelp/android/bento/core/BentoAsyncLayoutInflater.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/BentoAsyncLayoutInflater.kt
@@ -1,0 +1,42 @@
+package com.yelp.android.bento.core
+
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+private const val TAG = "BentoAsyncInflater"
+
+/**
+ * Inflates a componentViewHolder's views on one of ten lucky background threads.
+ */
+internal object BentoAsyncLayoutInflater {
+
+    internal val dispatcher = Executors.newFixedThreadPool(10).asCoroutineDispatcher()
+
+    suspend fun inflate(
+        viewHolder: ComponentViewHolder<*, *>,
+        parent: ViewGroup,
+        inflaterDispatcher: CoroutineDispatcher = dispatcher
+    ): Pair<ComponentViewHolder<*, *>, View> =
+            withContext(inflaterDispatcher) {
+                val view = try {
+                    viewHolder.inflate(parent)
+                } catch (exception: RuntimeException) {
+                    // Probably a Looper failure, retry on the UI thread
+                    Log.w(
+                            TAG, "Failed to inflate resource in the background!" +
+                            " Retrying on the UI thread",
+                            exception
+                    )
+                    withContext(Dispatchers.Main) {
+                        viewHolder.inflate(parent)
+                    }
+                }
+                Pair(viewHolder, view)
+            }
+}

--- a/bento/src/main/java/com/yelp/android/bento/utils/BentoSettings.kt
+++ b/bento/src/main/java/com/yelp/android/bento/utils/BentoSettings.kt
@@ -1,0 +1,11 @@
+package com.yelp.android.bento.utils
+
+object BentoSettings {
+    /**
+     * Global toggle for the async inflation feature in
+     * [com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController]. When enabled,
+     * all RecyclerViewComponentControllers will try to inflate their component's views on a background
+     * thread. It's disabled by default.
+     */
+    @JvmStatic var asyncInflationEnabled = false
+}

--- a/bento/src/test/java/com/yelp/android/bento/core/AsyncInflationBridgeTest.kt
+++ b/bento/src/test/java/com/yelp/android/bento/core/AsyncInflationBridgeTest.kt
@@ -1,0 +1,89 @@
+package com.yelp.android.bento.core
+
+import android.content.Context
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import junit.framework.Assert.assertNotNull
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class AsyncInflationBridgeTest {
+
+    private lateinit var asyncInflationBridge: AsyncInflationBridge
+
+    private val scope: CoroutineScope = TestCoroutineScope()
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val recyclerView = spy(RecyclerView(context)).apply {
+            layoutManager = LinearLayoutManager(context)
+        }
+        asyncInflationBridge = spy(AsyncInflationBridge(
+                recyclerView,
+                asyncInflaterDispatcher = testDispatcher,
+                defaultBridgeDispatcher = testDispatcher
+        ))
+        whenever(asyncInflationBridge.coroutineScope).doReturn(scope)
+    }
+
+    @Test
+    fun asyncInflateViewsForComponent_oneComponentWithCount1_returnsExpectedResults() {
+        val component = ComponentGroupTest.createMockComponents(1)[0]
+        asyncInflationBridge.asyncInflateViewsForComponent(component) { }
+        val viewHolder = asyncInflationBridge.getViewHolder(TestComponentViewHolder::class.java)
+        assertNotNull(viewHolder)
+        val view = asyncInflationBridge.getView(viewHolder!!) // Deffo not null.
+        assertNotNull(view)
+    }
+
+    @Test
+    fun asyncInflateViewsForComponent_oneComponentWithCount2_returnsExpectedResults() {
+        val component = ComponentGroupTest.createMockComponents(1)[0]
+        whenever(component.count).doReturn(2)
+        asyncInflationBridge.asyncInflateViewsForComponent(component) { }
+        val viewHolder = asyncInflationBridge.getViewHolder(TestComponentViewHolder::class.java)
+        assertNotNull(viewHolder)
+        val view = asyncInflationBridge.getView(viewHolder!!) // Deffo not null.
+        assertNotNull(view)
+
+        val viewHolder2 = asyncInflationBridge.getViewHolder(TestComponentViewHolder::class.java)
+        assertNotEquals(viewHolder, viewHolder2)
+        val view2 = asyncInflationBridge.getView(viewHolder2!!)
+        assertNotEquals(view, view2)
+    }
+
+    @Test
+    fun asyncInflateViewsForComponent_twoComponentsWithCount1_produces4Views() {
+        val component1 = ComponentGroupTest.createMockComponents(2)[0]
+        val component2 = ComponentGroupTest.createMockComponents(2)[1]
+
+        asyncInflationBridge.asyncInflateViewsForComponent(component1) { }
+        asyncInflationBridge.asyncInflateViewsForComponent(component2) { }
+
+        val viewHolder = asyncInflationBridge.getViewHolder(TestComponentViewHolder::class.java)
+        val viewHolder1 = asyncInflationBridge.getViewHolder(TestComponentViewHolder::class.java)
+        assertNotEquals(viewHolder, viewHolder1)
+
+        val view = asyncInflationBridge.getView(viewHolder!!)
+        val view2 = asyncInflationBridge.getView(viewHolder1!!)
+        assertNotEquals(view, view2)
+    }
+}

--- a/bento/src/test/java/com/yelp/android/bento/core/ComponentGroupTest.java
+++ b/bento/src/test/java/com/yelp/android/bento/core/ComponentGroupTest.java
@@ -348,7 +348,7 @@ public class ComponentGroupTest {
         assertEquals(12, listComponent.getNumberLanes());
     }
 
-    private List<Component> createMockComponents(int numComponents) {
+    public static List<Component> createMockComponents(int numComponents) {
         List<Component> components = new ArrayList<>(numComponents);
         for (int i = 0; i < numComponents; i++) {
             Component mock = mock(Component.class);

--- a/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
+++ b/buildSrc/src/main/java/com/yelp/gradle/bento/GlobalDependencies.kt
@@ -18,9 +18,12 @@ object Versions {
     const val ANDROID_GRADLE = "4.2.0"
     const val ANDROID_X_APP_COMPAT = "1.0.0"
     const val ANDROID_X_CONSTRAINT_LAYOUT = "1.1.2"
+    const val ANDROID_X_CORE_CTX = "1.4.0"
+    const val ANDROID_X_LIFECYCLE = "2.3.1"
     const val ANDROID_X_MATERIAL = "1.0.0"
     const val ANDROID_X_RECYCLER_VIEW = "1.0.0"
     const val ANDROID_X_TEST = "1.1.0"
+    const val COROUTINES = "1.4.0"
     const val ESPRESSO = "3.1.0"
     const val GRADLE = "6.9"
     const val GUAVA = "28.1-android"
@@ -28,8 +31,9 @@ object Versions {
     const val KOTLIN = "1.3.72"
     const val MAVEN_PUBLISH = "3.6.2"
     const val MAVEN_SETTINGS = "0.5"
-    const val MOCKITO = "2.7.19"
+    const val MOCKITO = "3.11.2"
     const val MOCKITO_KOTLIN = "2.1.0"
+    const val ROBOLECTRIC = "4.4"
     const val RX_JAVA_3 = "3.0.7"
     const val SUPPORT_TEST = "1.0.2"
 }
@@ -41,6 +45,7 @@ object BuildScriptLibs {
 
 object Libs {
     const val APACHE_COMMONS = "org.apache.commons:commons-lang3:${Versions.APACHE_COMMONS}"
+    const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.COROUTINES}"
     const val GUAVA = "com.google.guava:guava:${Versions.GUAVA}"
     const val KOTLIN = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.KOTLIN}"
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN}"
@@ -57,15 +62,19 @@ object SupportLibs {
     const val CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:${Versions.ANDROID_X_CONSTRAINT_LAYOUT}"
     const val DESIGN = "com.google.android.material:material:${Versions.ANDROID_X_MATERIAL}"
     const val RECYCLERVIEW = "androidx.recyclerview:recyclerview:${Versions.ANDROID_X_RECYCLER_VIEW}"
+    const val LIFECYCLE = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROID_X_LIFECYCLE}"
 }
 
 object TestLibs {
+    const val CORE_KTX = "androidx.test:core-ktx:${Versions.ANDROID_X_CORE_CTX}"
+    const val COROUTINES_TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.COROUTINES}"
     const val ESPRESSO = "androidx.test.espresso:espresso-core:${Versions.ESPRESSO}"
     const val ESPRESSO_CONTRIB = "androidx.test.espresso:espresso-contrib:${Versions.ESPRESSO}"
     const val ESPRESSO_INTENTS = "androidx.test.espresso:espresso-intents:${Versions.ESPRESSO}"
     const val JUNIT = "junit:junit:${Versions.JUNIT}"
     const val MOCKITO = "org.mockito:mockito-core:${Versions.MOCKITO}"
     const val MOCKITO_KOTLIN = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.MOCKITO_KOTLIN}"
+    const val ROBOLECTRIC = "org.robolectric:robolectric:${Versions.ROBOLECTRIC}"
     const val SUPPORT_TEST_RULES = "androidx.test:rules:${Versions.ANDROID_X_TEST}"
     const val SUPPORT_TEST_RUNNER = "androidx.test:runner:${Versions.ANDROID_X_TEST}"
 }


### PR DESCRIPTION
### This change: 
Tried to use `AsyncLayoutInflater` to inflate views off of the main thread. `AsyncInflationBridge` acts as a ...bridge between `RecyclerViewComponentController` and the underlying `RecyclerView.Adapter`, intercepting the `addComponent()` calls and inflating components' views on a background thread. As a bonus, I offload some of the reflective `constructViewHolder` calls to a background thread and store 'em in a cache that `RecyclerViewComponentController` can use later.

### Does it help? 

Preliminary tests on a Pixel 4 XL (real device) show a ~25% improvement in render timings for the first few frames of every fragment / activity.

![image](https://user-images.githubusercontent.com/1381911/126168410-349e1421-4ded-4460-9d1c-0e92b1b30b79.png)
