### PR TITLE
Fixed a memory leak in the async inflation feature.

### DIFF
--- a/bento/src/main/java/com/yelp/android/bento/componentcontrollers/RecyclerViewComponentController.java
+++ b/bento/src/main/java/com/yelp/android/bento/componentcontrollers/RecyclerViewComponentController.java
@@ -343,6 +343,9 @@ public class RecyclerViewComponentController
         mComponentGroup.clear();
         removeVisibilityListeners();
         addVisibilityListeners();
+        if (mAsyncInflationEnabled) {
+            mAsyncInflationBridge.cancelAllInflationJobs();
+        }
     }
 
     @Override

--- a/bento/src/test/java/com/yelp/android/bento/core/AsyncInflationBridgeTest.kt
+++ b/bento/src/test/java/com/yelp/android/bento/core/AsyncInflationBridgeTest.kt
@@ -8,11 +8,9 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.whenever
 import junit.framework.Assert.assertNotNull
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
@@ -26,7 +24,6 @@ class AsyncInflationBridgeTest {
 
     private lateinit var asyncInflationBridge: AsyncInflationBridge
 
-    private val scope: CoroutineScope = TestCoroutineScope()
     private val testDispatcher = TestCoroutineDispatcher()
 
     @Before
@@ -41,7 +38,6 @@ class AsyncInflationBridgeTest {
                 asyncInflaterDispatcher = testDispatcher,
                 defaultBridgeDispatcher = testDispatcher
         ))
-        whenever(asyncInflationBridge.coroutineScope).doReturn(scope)
     }
 
     @Test


### PR DESCRIPTION
We were using whatever `lifecycleScope` `context` provided which lead to a memory leak when Bento was used in Fragments. The lifecycleScope was tied to the parent activity's lifecycle instead of the fragment and thus, unused inflated views would stick around in memory.

The solution I went with was to abandon the lifecycleScope and use a SupervisorJob that we clear ourselves. `findViewTreeLifecycleOwner()` finds the Fragment lifecycle owner if there is one, which we can then add a listener to to get notified about the destroy event. Since some RecyclerView's are created inside ViewHolder's, they aren't attached yet at the time this code runs. To get around that, I used a `addOnAttachStateChangeListener`. If no fragment view lifecycle is found, we fallback to the activity's lifecycleScope.