### PR TITLE
fix: Disabled async bento for the CarouselComponent.

### DIFF
--- a/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
+++ b/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
@@ -81,7 +81,7 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
     final override fun inflate(parent: ViewGroup): View {
         return createRecyclerView(parent).apply {
             recyclerView = this
-            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL)
+            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL, false)
             isNestedScrollingEnabled = false
             (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
                 this.recycleChildrenOnDetach = true


### PR DESCRIPTION
The CarouselComponent recycles its views too often when scrolling which leads to a strange UI effect when the views get cleared and recreated.

To fix it, let's just disable async inflation for these carousels for now.