### PR TITLE
Smarter async view inflation.

### DIFF
--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
@@ -11,6 +11,7 @@ import com.yelp.android.bento.components.ListComponent
 import com.yelp.android.bento.components.NestedComponent
 import com.yelp.android.bento.components.NestedViewModel
 import com.yelp.android.bento.components.SimpleComponent
+import com.yelp.android.bento.core.AsyncInflationStrategy.DEFAULT
 import com.yelp.android.bento.core.Component
 import com.yelp.android.bento.core.ComponentController
 import com.yelp.android.bentosampleapp.components.AnimatedComponentExampleViewHolder
@@ -29,7 +30,11 @@ import kotlinx.android.synthetic.main.activity_recycler_view.*
 class RecyclerViewActivity : AppCompatActivity() {
 
     private val componentController by lazy {
-        RecyclerViewComponentController(recyclerView)
+        RecyclerViewComponentController(recyclerView).apply {
+            setAsyncCacheKey("RecyclerViewActivity")
+            setAsyncStrategy(DEFAULT)
+            setNumberAboveTheFoldViewHolders(3)
+        }
     }
     private lateinit var componentToScrollTo: Component
 

--- a/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
+++ b/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.yelp.android.bento.R
 import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController
+import com.yelp.android.bento.core.AsyncInflationStrategy.SMART
 import com.yelp.android.bento.core.Component
 import com.yelp.android.bento.core.ComponentGroup
 import com.yelp.android.bento.core.ComponentViewHolder
@@ -81,7 +82,10 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
     final override fun inflate(parent: ViewGroup): View {
         return createRecyclerView(parent).apply {
             recyclerView = this
-            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL, false)
+            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL, true).apply {
+                setAsyncCacheKey("carousel")
+                setAsyncStrategy(SMART)
+            }
             isNestedScrollingEnabled = false
             (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
                 this.recycleChildrenOnDetach = true

--- a/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationBridge.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationBridge.kt
@@ -9,12 +9,17 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController.constructViewHolder
+import com.yelp.android.bento.core.AsyncInflationStrategy.BEST_GUESS
+import com.yelp.android.bento.core.AsyncInflationStrategy.DEFAULT
+import com.yelp.android.bento.core.AsyncInflationStrategy.SMART
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -22,10 +27,15 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+
+private const val DEFAULT_NUM_ABOVE_FOLD_VIEW_HOLDERS = 5
+private const val MAX_VIEWS = 40
+private const val VIEWS_PER_COMPONENT_THRESHOLD = 10
 
 /**
  * This acts as a bridge between RecyclerViewComponentController and the underlying
@@ -53,6 +63,29 @@ internal class AsyncInflationBridge @JvmOverloads constructor(
     private val viewMap = ConcurrentHashMap<ComponentViewHolder<*, *>, View?>()
     private val inflationJobs = ConcurrentHashMap<Component, Job>()
 
+    // Keeps track of whether or not we inflated the below the fold set of views yet.
+    private var belowTheFoldTriggered = false
+
+    // Keeps track of whether or not we inflated the above the fold set of views yet.
+    private var aboveTheFoldTriggered = false
+
+    // Tracks how many views have been inflated.
+    private val inflatedViewTracker = AtomicInteger(0)
+
+    var asyncCacheKey: String = recyclerView.id.toString()
+        set(value) {
+            smartAsyncCacheEmptyOnStart = !SmartAsyncInflationCache.containsKey(value)
+        }
+
+    var strategy = DEFAULT
+    var numberOfAboveTheFoldViewHolders = DEFAULT_NUM_ABOVE_FOLD_VIEW_HOLDERS
+
+    // Tracks if the async cache was empty for this RecyclerView before the RecyclerView was used.
+    // If it was empty, it means this is the first time the cache is being populated. We have to
+    // set this during this object's creation because there would be a cache hit as soon the first
+    // component is added to this [recyclerView].
+    private var smartAsyncCacheEmptyOnStart = !SmartAsyncInflationCache.containsKey(asyncCacheKey)
+
     init {
         if (recyclerView.isAttachedToWindow) {
             findAndAttachToLifecycleOwner()
@@ -62,32 +95,9 @@ internal class AsyncInflationBridge @JvmOverloads constructor(
                     findAndAttachToLifecycleOwner()
                     recyclerView.removeOnAttachStateChangeListener(this)
                 }
+
                 override fun onViewDetachedFromWindow(v: View?) = Unit
             })
-        }
-    }
-
-    /**
-     * Inflates the views and creates the view holder for [component] on a background thread,
-     * getting them nice and ready for RecyclerViewComponentController to use them.
-     */
-    fun asyncInflateViewsForComponent(component: Component, addComponentCallback: () -> Unit) {
-        inflationJobs[component] = launch(defaultBridgeDispatcher) {
-            val inflations = (0 until component.count).map { i ->
-                async {
-                    val viewHolderType = component.getHolderType(i)
-                    val viewHolder: ComponentViewHolder<*, *> = constructViewHolder(viewHolderType)
-                    addViewHolder(viewHolder, viewHolderType)
-                    val (_, view) = BentoAsyncLayoutInflater.inflate(viewHolder, recyclerView, asyncInflaterDispatcher)
-                    viewMap[viewHolder] = view
-                }
-            }
-            lock.withLock {
-                inflations.awaitAll()
-            }
-            withContext(Dispatchers.Main) {
-                executeAddComponentCallback(addComponentCallback)
-            }
         }
     }
 
@@ -116,11 +126,137 @@ internal class AsyncInflationBridge @JvmOverloads constructor(
      * Cancels [component]'s inflation job if the component was removed.
      */
     fun trackComponentRemoval(component: Component) {
-        inflationJobs[component]?.cancel()
+        inflationJobs.remove(component)?.cancel()
     }
 
     fun cancelAllInflationJobs() {
         clearResources()
+    }
+
+    /**
+     * Intercepts addComponent() calls from a RecyclerViewComponentController and pre-inflates
+     * views asynchronously based on the set [AsyncInflationStrategy].
+     */
+    fun asyncInflateViewsForComponent(component: Component, addComponentCallback: () -> Unit) {
+        if (strategy == DEFAULT) {
+            if (smartAsyncCacheEmptyOnStart) {
+                asyncInflateViewsBestGuess(component, addComponentCallback)
+            } else {
+                smartAsyncInflateViewsForComponent(addComponentCallback)
+            }
+        } else if (strategy == SMART) {
+            smartAsyncInflateViewsForComponent(addComponentCallback)
+        } else if (strategy == BEST_GUESS) {
+            asyncInflateViewsBestGuess(component, addComponentCallback)
+        }
+    }
+
+    /**
+     * The "SMART" strategy for async inflation where adding components blocks on inflating above
+     * the fold view holders before inflating below the fold view holders.
+     */
+    private fun smartAsyncInflateViewsForComponent(addComponentCallback: () -> Unit) {
+        launch(defaultBridgeDispatcher) {
+            // The lock will block all addComponent calls that occur until the above the fold
+            // view holders are inflated.
+            lock.withLock {
+                // Only inflate above the fold if the cache wasn't empty in create, the below the
+                // fold set hasn't been inflated yet and if there's a match for this page name in
+                // the cache.
+                if (!belowTheFoldTriggered && !smartAsyncCacheEmptyOnStart &&
+                        SmartAsyncInflationCache.containsKey(asyncCacheKey)) {
+                    if (!aboveTheFoldTriggered) {
+                        asyncInflateViewsIfPossible(true)
+                        aboveTheFoldTriggered = true
+                    }
+                }
+                withContext(Dispatchers.Main) {
+                    executeAddComponentCallback(addComponentCallback)
+                }
+            }
+            // Outside the lock. The second time it's called, it should inflate the below the fold
+            // view holders without blocking any more addComponent calls.
+            if (!belowTheFoldTriggered && !smartAsyncCacheEmptyOnStart &&
+                    SmartAsyncInflationCache.containsKey(asyncCacheKey)) {
+                        belowTheFoldTriggered = true
+                asyncInflateViewsIfPossible(false)
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun asyncInflateViewsIfPossible(isAboveTheFoldCall: Boolean) {
+        if (asyncCacheKey.isEmpty()) return // There's no work to do.
+
+        val mapToPrepare = SmartAsyncInflationCache[asyncCacheKey] ?: mutableMapOf()
+        if (mapToPrepare.isEmpty()) return // There's no work to do.
+
+        val aboveFoldKeys = mapToPrepare.keys.take(numberOfAboveTheFoldViewHolders)
+
+        val keysToUse = if (isAboveTheFoldCall) aboveFoldKeys else mapToPrepare.keys.subtract(aboveFoldKeys)
+
+        keysToUse.forEach { viewHolderType ->
+            val numberOfViewsToInflate: Int = mapToPrepare[viewHolderType] ?: 0
+            val inflations: List<Deferred<Unit>> = (0 until numberOfViewsToInflate).map {
+
+                coroutineScope {
+                    async {
+                        val viewHolder = constructViewHolder(viewHolderType as Class<out ComponentViewHolder<Any?, Any?>>?)
+                        addViewHolder(viewHolder, viewHolderType as Class<out ComponentViewHolder<*, *>>)
+                        val (_, view) = BentoAsyncLayoutInflater.inflate(viewHolder, recyclerView, asyncInflaterDispatcher)
+                        viewMap[viewHolder] = view
+                    }
+                }
+            }
+            inflations.awaitAll()
+        }
+    }
+
+    /**
+     * The "BEST_GUESS" strategy for async view inflation. Inflates views for [component] if
+     * its count is non-zero and if doing so doesn't inflate more
+     * than [MAX_VIEWS].
+     */
+    private fun asyncInflateViewsBestGuess(component: Component, addComponentCallback: () -> Unit) {
+        inflationJobs[component] = launch(defaultBridgeDispatcher) {
+            var numberOfViewsToInflate = component.count
+            // If there's more than 10, chances are they'll be recycled and more will go unused.
+            // Not gonna lie. It's a guess and could be improved.
+            numberOfViewsToInflate.coerceAtMost(VIEWS_PER_COMPONENT_THRESHOLD)
+
+            // If this amount would tip us over the MAX views value, only inflate enough
+            // to fill up to the max.
+            numberOfViewsToInflate = numberOfViewsToInflate
+                    .coerceAtMost(MAX_VIEWS - inflatedViewTracker.get())
+
+            // Skip the below coroutine if there are either 0 views to inflate.
+            if (numberOfViewsToInflate == 0) {
+                lock.withLock {
+                    // We still need the lock to make sure components are added in order. Otherwise,
+                    // these ones would add above previous components that are being inflated below.
+                }
+                withContext(Dispatchers.Main) {
+                    executeAddComponentCallback(addComponentCallback)
+                }
+            } else {
+                inflatedViewTracker.getAndAdd(numberOfViewsToInflate)
+                val inflations = (0 until numberOfViewsToInflate).map { i ->
+                    async {
+                        val viewHolderType = component.getHolderType(i)
+                        val viewHolder: ComponentViewHolder<*, *> = constructViewHolder(viewHolderType)
+                        addViewHolder(viewHolder, viewHolderType)
+                        val (_, view) = BentoAsyncLayoutInflater.inflate(viewHolder, recyclerView, asyncInflaterDispatcher)
+                        viewMap[viewHolder] = view
+                    }
+                }
+                lock.withLock {
+                    inflations.awaitAll()
+                }
+                withContext(Dispatchers.Main) {
+                    executeAddComponentCallback(addComponentCallback)
+                }
+            }
+        }
     }
 
     private fun addViewHolder(
@@ -171,6 +307,8 @@ internal class AsyncInflationBridge @JvmOverloads constructor(
     }
 
     private fun clearResources() {
+        belowTheFoldTriggered = false // Ideally we wouldn't have to reset these at all but, we do.
+        aboveTheFoldTriggered = false
         coroutineContext.cancelChildren()
         viewHolderMap.clear()
         viewMap.clear()

--- a/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationStrategy.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/AsyncInflationStrategy.kt
@@ -1,0 +1,17 @@
+package com.yelp.android.bento.core
+
+enum class AsyncInflationStrategy {
+    // The "Best Guess" strategy inflates views as components are added to a
+    // RecyclerViewComponentController. Guessing how many view holders and views are needed based
+    // on the component's 'count'.
+    BEST_GUESS,
+
+    // The "Smart" strategy" will only pre-inflate if there's a match in SmartAsyncInflationCache.
+    // Use this to completely avoid the "Best Guess" strategy.
+    SMART,
+
+    // The "Default" strategy uses the "BEST_GUESS" version the first time a RecyclerView is
+    // encountered, subsequent run-ins with the same RecyclerView will use the "SMART" strategy, as
+    // there should be data in SmartAsyncInflationCache then.
+    DEFAULT
+}

--- a/bento/src/main/java/com/yelp/android/bento/core/BentoAsyncLayoutInflater.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/BentoAsyncLayoutInflater.kt
@@ -3,6 +3,7 @@ package com.yelp.android.bento.core
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import com.yelp.android.bento.utils.BentoSettings
 import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -28,11 +29,12 @@ internal object BentoAsyncLayoutInflater {
                     viewHolder.inflate(parent)
                 } catch (exception: RuntimeException) {
                     // Probably a Looper failure, retry on the UI thread
-                    Log.w(
-                            TAG, "Failed to inflate resource in the background!" +
-                            " Retrying on the UI thread",
-                            exception
-                    )
+                    if (BentoSettings.loggingEnabled) {
+                        Log.w(TAG, "Failed to inflate resource in the background!" +
+                                " Retrying on the UI thread",
+                                exception
+                        )
+                    }
                     withContext(Dispatchers.Main) {
                         viewHolder.inflate(parent)
                     }

--- a/bento/src/main/java/com/yelp/android/bento/core/SmartAsyncInflationCache.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/SmartAsyncInflationCache.kt
@@ -1,0 +1,33 @@
+package com.yelp.android.bento.core
+
+private const val CACHE_SIZE_LIMIT = 30
+
+/**
+ * Cache of how many of each view holder type's were actually inflated. This is a map of a name of
+ * a screen, to map of ViewHolder type's to how many view holder type's were requested.
+ */
+object SmartAsyncInflationCache : LinkedHashMap<String, MutableMap<Any, Int?>>() {
+
+    fun incrementForViewHolder(name: String, viewHolderType: Any) {
+        val existingMap = this.getOrPut(name) { mutableMapOf() }
+        val existingCount = (existingMap[viewHolderType] ?: 0) + 1
+        existingMap[viewHolderType] = existingCount
+    }
+
+    fun incrementForViewHolderIfMissing(name: String, viewHolderType: Any): Boolean {
+        val existingMap = this.getOrPut(name) { mutableMapOf() }
+        if (existingMap.isEmpty()) {
+            val existingCount = (existingMap[viewHolderType] ?: 0) + 1
+            existingMap[viewHolderType] = existingCount
+            this[name] = existingMap
+            return true // If it was empty, return true so we know to keep tracking this.
+        }
+        return false
+    }
+
+    override fun removeEldestEntry(
+        eldest: MutableMap.MutableEntry<String, MutableMap<Any, Int?>>?
+    ): Boolean {
+        return size > CACHE_SIZE_LIMIT
+    }
+}

--- a/bento/src/main/java/com/yelp/android/bento/utils/BentoSettings.kt
+++ b/bento/src/main/java/com/yelp/android/bento/utils/BentoSettings.kt
@@ -1,11 +1,16 @@
 package com.yelp.android.bento.utils
 
 object BentoSettings {
+
+    const val BENTO_TAG = "bento"
+
     /**
      * Global toggle for the async inflation feature in
      * [com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController]. When enabled,
-     * all RecyclerViewComponentControllers will try to inflate their component's views on a background
-     * thread. It's disabled by default.
+     * all RecyclerViewComponentControllers will try to inflate their component's views on a
+     * background thread. It's disabled by default.
      */
     @JvmStatic var asyncInflationEnabled = false
+
+    @JvmStatic var loggingEnabled = false
 }


### PR DESCRIPTION
This implementation for async view inflation tracks how many view holders and views were actually needed by a page in a cache, and then uses it to inflate the number of view holders when the first component is added the next time the page is created.

This has some benefits:

- We inflate less views in total and have less unused views when someone scrolls to the bottom. Therefore, it uses less memory overall.
- We get a higher hit % from the cache of pre-inflated views so the ui will be smoother. Some pages that add components without data were getting a lot of misses with the other implementation.

And some drawbacks:
- Navigating to a page one time bypasses async view inflation completely.
- This implementation blocks the ui waiting for above the fold components, although it's lightning fast, the height of components impacts how many are actually above the fold or not from page to page.

Note: I deleted the old implementation here but keeping both and allowing each RecyclerViewComponentController to specify a different async inflation strategy could be a worthwhile.