### PR TITLE
fix: Fixed a few bugs in the smart async implementation.

### DIFF
--- a/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
+++ b/bento-sample-app/src/main/java/com/yelp/android/bentosampleapp/RecyclerViewActivity.kt
@@ -33,7 +33,7 @@ class RecyclerViewActivity : AppCompatActivity() {
         RecyclerViewComponentController(recyclerView).apply {
             setAsyncCacheKey("RecyclerViewActivity")
             setAsyncStrategy(DEFAULT)
-            setNumberAboveTheFoldViewHolders(3)
+            setNumberAboveTheFoldViewHolders(12)
         }
     }
     private lateinit var componentToScrollTo: Component

--- a/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
+++ b/bento/src/main/java/com/yelp/android/bento/components/CarouselComponent.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.yelp.android.bento.R
 import com.yelp.android.bento.componentcontrollers.RecyclerViewComponentController
-import com.yelp.android.bento.core.AsyncInflationStrategy.SMART
 import com.yelp.android.bento.core.Component
 import com.yelp.android.bento.core.ComponentGroup
 import com.yelp.android.bento.core.ComponentViewHolder
@@ -82,10 +81,7 @@ open class CarouselComponentViewHolder : ComponentViewHolder<Unit?, CarouselView
     final override fun inflate(parent: ViewGroup): View {
         return createRecyclerView(parent).apply {
             recyclerView = this
-            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL, true).apply {
-                setAsyncCacheKey("carousel")
-                setAsyncStrategy(SMART)
-            }
+            controller = RecyclerViewComponentController(recyclerView, RecyclerView.HORIZONTAL, false)
             isNestedScrollingEnabled = false
             (recyclerView.layoutManager as? LinearLayoutManager)?.apply {
                 this.recycleChildrenOnDetach = true

--- a/bento/src/main/java/com/yelp/android/bento/core/SmartAsyncInflationCache.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/SmartAsyncInflationCache.kt
@@ -1,32 +1,30 @@
 package com.yelp.android.bento.core
 
+import kotlin.collections.LinkedHashMap
+
 private const val CACHE_SIZE_LIMIT = 30
 
 /**
  * Cache of how many of each view holder type's were actually inflated. This is a map of a name of
  * a screen, to map of ViewHolder type's to how many view holder type's were requested.
  */
-object SmartAsyncInflationCache : LinkedHashMap<String, MutableMap<Any, Int?>>() {
+object SmartAsyncInflationCache : LinkedHashMap<String, MutableList<Any>>() {
 
     fun incrementForViewHolder(name: String, viewHolderType: Any) {
-        val existingMap = this.getOrPut(name) { mutableMapOf() }
-        val existingCount = (existingMap[viewHolderType] ?: 0) + 1
-        existingMap[viewHolderType] = existingCount
+        getOrPut(name) { mutableListOf() }.add(viewHolderType)
     }
 
     fun incrementForViewHolderIfMissing(name: String, viewHolderType: Any): Boolean {
-        val existingMap = this.getOrPut(name) { mutableMapOf() }
-        if (existingMap.isEmpty()) {
-            val existingCount = (existingMap[viewHolderType] ?: 0) + 1
-            existingMap[viewHolderType] = existingCount
-            this[name] = existingMap
+        val existingList = getOrPut(name) { mutableListOf() }
+        if (existingList.isNotEmpty() && !existingList.contains(viewHolderType)) {
+            existingList.add(viewHolderType)
             return true // If it was empty, return true so we know to keep tracking this.
         }
         return false
     }
 
     override fun removeEldestEntry(
-        eldest: MutableMap.MutableEntry<String, MutableMap<Any, Int?>>?
+        eldest: MutableMap.MutableEntry<String, MutableList<Any>>?
     ): Boolean {
         return size > CACHE_SIZE_LIMIT
     }


### PR DESCRIPTION
I found a few bugs in my previous PR.

1. The setter for `asyncCacheKey` was missing the part that actually sets the property
2. View holders weren't all being inflated in parallel. We were paralleling per view holder type.
3. `numberOfViewHoldersToInflate` actually represented `numberOfViewHolderTypesToInflate` which lead to too many view holders being inflated for the above the fold set.
4. I never actually meant to commit the CarouselComponent change. It still behaves strangely.

I switched `SmartAsyncInflationCache` to use a list instead of a map of types to counts and it seems to speed things up greatly.