### PR TITLE
fix(publishing): Fixing publishing to Maven Central

### DIFF
--- a/publishing.gradle
+++ b/publishing.gradle
@@ -71,6 +71,10 @@ afterEvaluate {
     }
 }
 
+signing {
+    required { project.hasProperty("signing.keyId") }
+    sign publishing.publications.matching { "release" }
+}
 
 static def isReleaseBuild() {
     return !Publishing.VERSION.endsWith("-SNAPSHOT")


### PR DESCRIPTION
The signing task had been removed, so we weren't properly signing artifacts when publishing to maven. The task is now added back and working properly.