### PR TITLE
Compose view holder fails to update correctly when the component state changes

### DIFF
--- a/bento-compose/src/test/java/com/yelp/android/bento/compose/ComposeViewHolderTest.kt
+++ b/bento-compose/src/test/java/com/yelp/android/bento/compose/ComposeViewHolderTest.kt
@@ -15,11 +15,20 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ComposeViewHolderTest {
 
-    @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     internal data class MyViewModel(val name: String)
 
-    internal class MyTestComponent(val name: String) : Component() {
+    internal class MyTestComponent(initialValue: String) : Component() {
+
+        private var name: String = initialValue
+
+        fun updateName(name: String) {
+            this.name = name
+            notifyDataChanged()
+        }
+
         override fun getPresenter(position: Int) = Presenter()
 
         override fun getItem(position: Int) = MyViewModel(name)
@@ -50,5 +59,31 @@ class ComposeViewHolderTest {
             }
         }
         composeTestRule.onNodeWithText(name).assertIsDisplayed()
+    }
+
+    @Test
+    fun `compose view holder handle updates correctly`() {
+        val initialValue = "Initial Value"
+        val firstUpdate = "First Update"
+        val secondUpdate = "Second Update"
+        val component = MyTestComponent(initialValue = initialValue)
+        composeTestRule.setContent {
+            RecyclerView {
+                RecyclerViewComponentController(it).apply {
+                    addComponent(component)
+                }
+            }
+        }
+
+        // First time
+        composeTestRule.onNodeWithText(initialValue).assertIsDisplayed()
+
+        // Second time
+        component.updateName(firstUpdate)
+        composeTestRule.onNodeWithText(firstUpdate).assertIsDisplayed()
+
+        // Third time
+        component.updateName(secondUpdate)
+        composeTestRule.onNodeWithText(secondUpdate).assertIsDisplayed()
     }
 }


### PR DESCRIPTION
### Bug:
It seems that the Compose view holder fails to update correctly when the component state changes. This issue mainly arises from the fact that `private val rowStates = mutableMapOf<Int, MutableState<T>>()` caches the old data. I'm not sure why we are caching the data because it doesn't seem necessary, considering that the data is already a parameter in method `override fun bind(presenter: P, element: T)`.

### Testing Scenario:
First Update:
![Screenshot 2023-09-12 at 13 12 51](https://github.com/Yelp/bento/assets/13536749/bdc7f972-2273-45e7-ae77-a2544ddbdceb)
Second Update:
![Screenshot 2023-09-12 at 13 12 59](https://github.com/Yelp/bento/assets/13536749/e755b5e2-9800-4ec9-ab5c-8aefbb2d15d1)
Third Update:
![Screenshot 2023-09-12 at 13 13 06](https://github.com/Yelp/bento/assets/13536749/7a004478-9036-4474-9a57-df23c65667b1)

### Verification 
"ComposeViewHolderTest.`compose view holder handle updates correctly`"
