### PR TITLE
Deprecating Bento

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-<img src="./documentation/images/bento_logo.png" width="80%"/>
+# ⛔️ DEPRECATED <Bento>
+This is no longer supported, please consider using [Jetpack Compose](https://developer.android.com/develop/ui/compose) instead.
 
-## A delicious framework for building modularized Android user interfaces, by Yelp.
+<img src="./documentation/images/bento_logo.png" width="20%"/>
 
+### A delicious framework for building modularized Android user interfaces, by Yelp.
+![No Maintenance Intended](https://unmaintained.tech/badge.svg)
 ![Maven Central](https://img.shields.io/maven-central/v/com.yelp.android/bento.svg)
 [![Build Status](https://travis-ci.org/Yelp/bento.svg?branch=master)](https://travis-ci.org/Yelp/bento)
 [![Twitter](https://img.shields.io/badge/Twitter-@YelpEngineering-blue.svg)](https://twitter.com/YelpEngineering)
@@ -54,9 +57,9 @@ Bento can be setup with Gradle:
 ```groovy
 // Top level build.gradle
 allprojects {
-	repositories {
-		mavenCentral()
-	}
+    repositories {
+        mavenCentral()
+    }
 }
 
 // Module level build.gradle

--- a/bento-compose/src/main/java/com/yelp/android/bento/compose/ComposeViewHolder.kt
+++ b/bento-compose/src/main/java/com/yelp/android/bento/compose/ComposeViewHolder.kt
@@ -11,9 +11,12 @@ import androidx.compose.ui.platform.ComposeView
 import com.yelp.android.bento.core.ComponentViewHolder
 
 /**
- * ViewHolder which allows compatability with Jetpack Compose. Basically, this lets you write the
+ * ViewHolder which allows compatibility with Jetpack Compose. Basically, this lets you write the
  * view holders view code with Compose.
  */
+@Deprecated(
+    message = "Bento is deprecated! Only use ComposeViewHolder temporarily while migrating to full Jetpack Compose. Note that using Compose inside Bento may reduce performance. Please ensure a plan to migrate fully to Jetpack Compose soon.",
+)
 abstract class ComposeViewHolder<P, T> : ComponentViewHolder<P, T>() {
 
     private lateinit var composeView: ComposeView

--- a/bento/src/main/java/com/yelp/android/bento/core/Component.java
+++ b/bento/src/main/java/com/yelp/android/bento/core/Component.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * @deprecated Bento is deprecated!
+ * <p>Please consider using Jetpack Compose https://developer.android.com/jetpack/compose instead.</p>
+ * <br>
  * The building block of user interfaces in the Bento framework. Represents a self-contained
  * component to be used with a {@link ComponentController}.
  *
@@ -20,6 +23,7 @@ import java.util.List;
  * a user interface as a series of modular components instead of a complicated set of internal items
  * whose state must be managed by the component.
  */
+@Deprecated
 public abstract class Component {
 
     private final ComponentDataObservable mObservable = new ComponentDataObservable();

--- a/bento/src/main/java/com/yelp/android/bento/core/ComponentController.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/ComponentController.kt
@@ -8,6 +8,9 @@ import com.yelp.android.bento.utils.AccordionList.Range
  * <br></br><br></br>
  * See: [Component], [ComponentViewHolder]
  */
+@Deprecated(
+    message = "Bento is deprecated! Please consider using Jetpack Compose https://developer.android.com/jetpack/compose instead.",
+)
 interface ComponentController {
 
     /**

--- a/bento/src/main/java/com/yelp/android/bento/core/ComponentGroup.java
+++ b/bento/src/main/java/com/yelp/android/bento/core/ComponentGroup.java
@@ -16,10 +16,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
+ * @deprecated Bento is deprecated!
+ * <p>Please consider using Jetpack Compose https://developer.android.com/jetpack/compose instead.</p>
+ * <br>
  * A {@link Component} comprising of zero or more ordered child {@link Component}s. Useful for
  * maintaining a group of related components in close proximity to each other in the {@link
  * ComponentController}.
  */
+@Deprecated
 public class ComponentGroup extends Component {
 
     /**

--- a/bento/src/main/java/com/yelp/android/bento/core/ComponentViewHolder.kt
+++ b/bento/src/main/java/com/yelp/android/bento/core/ComponentViewHolder.kt
@@ -15,6 +15,9 @@ import android.view.ViewGroup
  * no-arg constructor. Unfortunately, this means all subclasses must be visible from this package
  * and provide a no-arg constructor.
  */
+@Deprecated(
+    message = "Bento is deprecated! Please consider using Jetpack Compose https://developer.android.com/jetpack/compose instead.",
+)
 abstract class ComponentViewHolder<P, T> {
 
     /**


### PR DESCRIPTION
### Problem
There are 2 competing technologies to build Android user interfaces, Android View System(XML), being around since the first version of Android in 2008 and Jetpack Compose, the new modern toolkit with first prod release in 2021. Bento was originally built to complement the Android View System, facilitating feature development for scrollable screens since 2017. With Jetpack Compose, we can achieve equivalent functionality much faster without the need for Bento. We are now deprecating Bento and fully embrace Jetpack Compose.

### Solution
Update README to reflect the deprecation of Bento repository clearly.
Mark ComposeViewHolder as deprecated. ComposeViewHolder should only be used temporarily when gradually migrating to full Jetpack Compose. Use full Jetpack Compose when possible is recommended.