### PR TITLE
Set ComposeViewHolder to match parent

### DIFF
--- a/bento-compose/src/main/java/com/yelp/android/bento/compose/ComposeViewHolder.kt
+++ b/bento-compose/src/main/java/com/yelp/android/bento/compose/ComposeViewHolder.kt
@@ -34,6 +34,10 @@ abstract class ComposeViewHolder<P, T> : ComponentViewHolder<P, T>() {
                     element = element ?: return@setContent
                 )
             }
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
         }
         return composeView
     }


### PR DESCRIPTION
For some rare case, with ComposeViewHolder wrap content, it is hard for sub composable to align with the screen size. Adding match parent to ComposeViewHolder will enable it.